### PR TITLE
Set SSL config API access for Unity as a string

### DIFF
--- a/UnityProject/Assets/Scripts/WorldControls.cs
+++ b/UnityProject/Assets/Scripts/WorldControls.cs
@@ -103,9 +103,9 @@ public class WorldControls : MonoBehaviour
         io.settings.path = path;
     }
 
-    public void SetSSL(bool isSSLEnabled)
+    public void SetSSL(string isSSLEnabled)
     {
-        io.settings.sslEnabled = isSSLEnabled;
+        io.settings.sslEnabled = Convert.ToBoolean(isSSLEnabled);
     }
 
     // Set main user.

--- a/UnityProject/ProjectSettings/GraphicsSettings.asset
+++ b/UnityProject/ProjectSettings/GraphicsSettings.asset
@@ -37,6 +37,7 @@ GraphicsSettings:
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10782, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
- Changes SetSSL method param to String, and then converts it to boolean on Unity side. Python's boolean is uppercase, all other languages are lowercase; hence the issue.