### PR TITLE
Minor Test Fixes. Closes #201 and #202

### DIFF
--- a/UnityProject/Assets/Editor/Tests/OverlayGeneratorTests.cs
+++ b/UnityProject/Assets/Editor/Tests/OverlayGeneratorTests.cs
@@ -1,15 +1,23 @@
 using UnityEngine;
 using NUnit.Framework;
-using MapFeatures.Pickups;
+using UnityEditor.SceneManagement;
+
 
 namespace AIMMOUnityTest
 {
     [TestFixture]
     internal class OverlayGeneratorTests
     {
+        private void SetUpMainScene()
+        {
+            EditorSceneManager.OpenScene("Assets/Scenes/Main.unity", OpenSceneMode.Single);
+        }
+
         [Test]
         public void TestGridGeneratedByDTO()
         {
+            SetUpMainScene();
+
             TerrainDTO terrainDTO = new TerrainDTO(81, 2);
             GameObject terrainFolder = new GameObject();
             OverlayGenerator overlayGenerator = new OverlayGenerator(terrainFolder: terrainFolder);

--- a/UnityProject/Assets/Editor/Tests/PlayerGeneratorTest.cs
+++ b/UnityProject/Assets/Editor/Tests/PlayerGeneratorTest.cs
@@ -11,9 +11,10 @@ namespace AIMMOUnityTest
         [Test]
         public void TestGeneratePlayerByPrefab()
         {
+            GameObject playersFolder = GameObject.Find("Players");
             GameObject deePrefab = Resources.Load<GameObject>("Prefabs/Players/player_dee");
 
-            GameObject generatedPlayer = PlayerGenerator.GeneratePlayer(deePrefab);
+            GameObject generatedPlayer = PlayerGenerator.GeneratePlayer(deePrefab, playersFolder);
 
             Assert.AreEqual(0, generatedPlayer.transform.localPosition.x);
             Assert.AreEqual(0, generatedPlayer.transform.localPosition.y);
@@ -27,10 +28,12 @@ namespace AIMMOUnityTest
         {
             PlayerDTO playerDTO = new PlayerDTO();
             Location playerLocation = new Location(10, 20);
+            GameObject playersFolder = GameObject.Find("Players");
+
             playerDTO.location = playerLocation;
             playerDTO.id = 1;
 
-            GameObject generatedPlayer = PlayerGenerator.GeneratePlayer(playerDTO);
+            GameObject generatedPlayer = PlayerGenerator.GeneratePlayer(playerDTO, playersFolder);
 
             Assert.AreEqual(playerLocation.x, generatedPlayer.transform.localPosition.x);
             Assert.AreEqual(0, generatedPlayer.transform.localPosition.y);

--- a/UnityProject/Assets/Scripts/Generators/PlayerGenerator.cs
+++ b/UnityProject/Assets/Scripts/Generators/PlayerGenerator.cs
@@ -12,7 +12,6 @@ public class PlayerGenerator : MonoBehaviour
     void Awake()
     {
         playersFolder = GameObject.Find("Players");
-        Debug.Log(playersFolder);
     }
 
     public static GameObject GeneratePlayer(GameObject playerPrefab, GameObject playerFolder = null)

--- a/UnityProject/Assets/Scripts/Generators/PlayerGenerator.cs
+++ b/UnityProject/Assets/Scripts/Generators/PlayerGenerator.cs
@@ -12,6 +12,7 @@ public class PlayerGenerator : MonoBehaviour
     void Awake()
     {
         playersFolder = GameObject.Find("Players");
+        Debug.Log(playersFolder);
     }
 
     public static GameObject GeneratePlayer(GameObject playerPrefab, GameObject playerFolder = null)


### PR DESCRIPTION
When doing PR #198 I realised that the tests are failing for completely different reasons which we missed out on. No continuous integration with the test runner so we missed it :~

- PR #191 broke tests `TestGeneratePlayerByPrefab()` and `TestGeneratePlayerByDTO()`. This is because we changed the definition of the method `PlayerGenerator.GeneratePlayer()` slightly. Solves #201. Passed now as below:

![collage1](https://user-images.githubusercontent.com/22431381/37666862-77873f08-2c58-11e8-96a8-1edae97477d9.jpg)
- Test `TestGridGeneratedByDTO()` fails because this is dependant on the current open scene in the editor. Forcing main scene to be open. Also passes now:

<img width="478" alt="screen shot 2018-03-20 at 16 11 14" src="https://user-images.githubusercontent.com/22431381/37667215-5f92d49c-2c59-11e8-802e-1e62151c8a33.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo-unity/203)
<!-- Reviewable:end -->
