### PR TITLE
Camera doesn't move outside of the map

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Terrains/terrain_future_default.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Terrains/terrain_future_default.prefab
@@ -21,6 +21,7 @@ GameObject:
   - component: {fileID: 4795511686184722}
   - component: {fileID: 33218429090856482}
   - component: {fileID: 23053202819628740}
+  - component: {fileID: 64136541148052650}
   m_Layer: 0
   m_Name: terrain_future_default
   m_TagString: Terrain
@@ -54,6 +55,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 4b2e31f4f96dc452cb2435fe1451d061, type: 2}
   m_StaticBatchInfo:
@@ -81,4 +83,18 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1607405648880568}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!64 &64136541148052650
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1607405648880568}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_SkinWidth: 0.01
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}

--- a/UnityProject/Assets/Scripts/Camera/MoveCamera.cs
+++ b/UnityProject/Assets/Scripts/Camera/MoveCamera.cs
@@ -66,16 +66,18 @@ public class MoveCamera : MonoBehaviour
 
     private bool IsMapVisible()
     {
-        bool foundMap = false;
 
         hits = Physics.RaycastAll(transform.position, transform.forward, 100.0F);
 
         foreach (RaycastHit hit in hits)
         {
-            foundMap |= hit.transform.gameObject.tag == "Terrain";
+            if (hit.transform.gameObject.tag == "Terrain")
+            {
+                return true;
+            }
         }
 
-        return foundMap;
+        return false;
     }
 
     private void ContinueDrag()

--- a/UnityProject/Assets/Scripts/Camera/MoveCamera.cs
+++ b/UnityProject/Assets/Scripts/Camera/MoveCamera.cs
@@ -8,8 +8,9 @@ public class MoveCamera : MonoBehaviour
     private float maxCameraCap = 7.0f;
 
     private RaycastHit[] hits;
-    private bool foundMap = true;
-    private Vector3 prevIncr;
+    private Vector3 previousTranslation;
+    private Ray mouseRay;
+    private float offset;
 
     private KeyCode dragKey = KeyCode.Mouse0; // left mouse button
 
@@ -32,16 +33,8 @@ public class MoveCamera : MonoBehaviour
     {
         // PAN
         float offset; // distance from camera's ray to drag origin ray
-        Ray mouseRay = Camera.main.ScreenPointToRay(Input.mousePosition); // drag origin ray
-        foundMap = false;
+        mouseRay = Camera.main.ScreenPointToRay(Input.mousePosition); // drag origin ray
 
-        // Check if map is visible
-        hits = Physics.RaycastAll(transform.position, transform.forward, 100.0F);
-
-        foreach (RaycastHit hit in hits)
-        {
-            foundMap |= hit.transform.gameObject.tag == "Terrain";
-        }
 
         // Start drag
         if (Input.GetKeyDown(dragKey))
@@ -53,18 +46,7 @@ public class MoveCamera : MonoBehaviour
         // Continue drag
         if (Input.GetKey(dragKey))
         {
-            groundPlane.Raycast(mouseRay, out offset);
-            Vector3 intersection = mouseRay.GetPoint(offset);
-
-            if (foundMap)
-            {
-                prevIncr = dragOrigin - intersection;
-                transform.position += prevIncr;
-            }
-            else
-            {
-                transform.position -= prevIncr;
-            }
+            ContinueDrag();
         }
 
 
@@ -79,6 +61,36 @@ public class MoveCamera : MonoBehaviour
         else if (scroll < 0)
         {
             Camera.main.orthographicSize = Mathf.Min(Camera.main.orthographicSize + zoomSpeed, maxCameraCap);
+        }
+    }
+
+    private bool IsMapVisible()
+    {
+        bool foundMap = false;
+
+        hits = Physics.RaycastAll(transform.position, transform.forward, 100.0F);
+
+        foreach (RaycastHit hit in hits)
+        {
+            foundMap |= hit.transform.gameObject.tag == "Terrain";
+        }
+
+        return foundMap;
+    }
+
+    private void ContinueDrag()
+    {
+        groundPlane.Raycast(mouseRay, out offset);
+        Vector3 intersection = mouseRay.GetPoint(offset);
+
+        if (IsMapVisible())
+        {
+            previousTranslation = dragOrigin - intersection;
+            transform.position += previousTranslation;
+        }
+        else
+        {
+            transform.position -= previousTranslation;
         }
     }
 }

--- a/UnityProject/Assets/Scripts/Camera/MoveCamera.cs
+++ b/UnityProject/Assets/Scripts/Camera/MoveCamera.cs
@@ -8,9 +8,9 @@ public class MoveCamera : MonoBehaviour
     private float maxCameraCap = 7.0f;
 
     private RaycastHit[] hits;
-    private Vector3 previousTranslation;
+    private Vector3 cameraTranslation;
     private Ray mouseRay;
-    private float offset;
+    private float mouseTranslation; // distance from camera's ray to drag origin ray
 
     private KeyCode dragKey = KeyCode.Mouse0; // left mouse button
 
@@ -32,9 +32,7 @@ public class MoveCamera : MonoBehaviour
     public void Update()
     {
         // PAN
-        float offset; // distance from camera's ray to drag origin ray
         mouseRay = Camera.main.ScreenPointToRay(Input.mousePosition); // drag origin ray
-
 
         // Start drag
         if (Input.GetKeyDown(dragKey))
@@ -82,17 +80,17 @@ public class MoveCamera : MonoBehaviour
 
     private void ContinueDrag()
     {
-        groundPlane.Raycast(mouseRay, out offset);
-        Vector3 intersection = mouseRay.GetPoint(offset);
+        groundPlane.Raycast(mouseRay, out mouseTranslation);
+        Vector3 intersection = mouseRay.GetPoint(mouseTranslation);
 
         if (IsMapVisible())
         {
-            previousTranslation = dragOrigin - intersection;
-            transform.position += previousTranslation;
+            cameraTranslation = dragOrigin - intersection;
+            transform.position += cameraTranslation;
         }
         else
         {
-            transform.position -= previousTranslation;
+            transform.position -= cameraTranslation;
         }
     }
 }

--- a/UnityProject/Assets/Scripts/Camera/MoveCamera.cs
+++ b/UnityProject/Assets/Scripts/Camera/MoveCamera.cs
@@ -7,6 +7,10 @@ public class MoveCamera : MonoBehaviour
     private float minCameraCap = 1.2f;
     private float maxCameraCap = 7.0f;
 
+    private RaycastHit[] hits;
+    private bool foundMap = true;
+    private Vector3 prevIncr;
+
     private KeyCode dragKey = KeyCode.Mouse0; // left mouse button
 
     // Ground plane we will drag the camera on
@@ -29,6 +33,15 @@ public class MoveCamera : MonoBehaviour
         // PAN
         float offset; // distance from camera's ray to drag origin ray
         Ray mouseRay = Camera.main.ScreenPointToRay(Input.mousePosition); // drag origin ray
+        foundMap = false;
+
+        // Check if map is visible
+        hits = Physics.RaycastAll(transform.position, transform.forward, 100.0F);
+
+        foreach (RaycastHit hit in hits)
+        {
+            foundMap |= hit.transform.gameObject.tag == "Terrain";
+        }
 
         // Start drag
         if (Input.GetKeyDown(dragKey))
@@ -42,8 +55,18 @@ public class MoveCamera : MonoBehaviour
         {
             groundPlane.Raycast(mouseRay, out offset);
             Vector3 intersection = mouseRay.GetPoint(offset);
-            transform.position += dragOrigin - intersection;
+
+            if (foundMap)
+            {
+                prevIncr = dragOrigin - intersection;
+                transform.position += prevIncr;
+            }
+            else
+            {
+                transform.position -= prevIncr;
+            }
         }
+
 
         // ZOOM
         // Mouse scrollwheel to zoom in fixed increments


### PR DESCRIPTION
Added a mesh collider to the future terrain prefab and changed the camera movement script to reset the camera's position once it is dragged outside boundaries.

---
The camera doesn't let the terrain object exit its centre. There's a ghost effect when the camera gets dragged back.

---

Added/Changed Features:
+ Mesh collider on terrain prefab
+ Code check for the terrain position relative to the camera's forward vector
+ Position fix when the camera moves past the map

Added Tests:
+ No camera tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo-unity/239)
<!-- Reviewable:end -->
